### PR TITLE
Fix +1s not appearing when browsing to an issue

### DIFF
--- a/content_script.js
+++ b/content_script.js
@@ -51,9 +51,20 @@ function removePlusOnes() {
 }
 
 var observer = new MutationObserver(function(mutations) {
-  removePlusOnes();
+  var needsRemoval = false;
+  mutations.forEach(function(mutation) {
+    Array.prototype.slice.call(mutation.addedNodes).forEach(function(node) {
+      if (node instanceof Element && node.querySelector(".js-discussion")) {
+        needsRemoval = true;
+      }
+    });
+  });
+
+  if (needsRemoval) {
+    removePlusOnes();
+  }
 });
 
-observer.observe(document.querySelector('div.js-discussion'), {childList: true});
+observer.observe(document, {childList: true, subtree: true});
 
 removePlusOnes();

--- a/content_script.js
+++ b/content_script.js
@@ -54,7 +54,7 @@ var observer = new MutationObserver(function(mutations) {
   var needsRemoval = false;
   mutations.forEach(function(mutation) {
     Array.prototype.slice.call(mutation.addedNodes).forEach(function(node) {
-      if (node instanceof Element && (node.querySelector(".js-discussion") || node.classList.contains("js-discussion"))) {
+      if (node instanceof Element && (node.querySelector(".js-comment") || node.classList.contains("js-comment"))) {
         needsRemoval = true;
       }
     });

--- a/content_script.js
+++ b/content_script.js
@@ -54,7 +54,7 @@ var observer = new MutationObserver(function(mutations) {
   var needsRemoval = false;
   mutations.forEach(function(mutation) {
     Array.prototype.slice.call(mutation.addedNodes).forEach(function(node) {
-      if (node instanceof Element && node.querySelector(".js-discussion")) {
+      if (node instanceof Element && (node.querySelector(".js-discussion") || node.classList.contains("js-discussion"))) {
         needsRemoval = true;
       }
     });


### PR DESCRIPTION
Currently, browsing to an issue doesn't cause the +1 bar to appear. With these changes, browsing around works as expected.

Not positive if there's a better way to do the checking—I'm not super familiar with mutation observers.
