### PR TITLE
Add GitHub Enterprise support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,10 @@
 [![GitHub +1 Chrome Extension](http://i.imgur.com/wJLc7R4.png)](https://chrome.google.com/webstore/detail/github-%201s/lddfkkebajnpiicnpfamebilmhamkeme)
 
 More information and installation instructions can be found [here](https://chrome.google.com/webstore/detail/github-%201s/lddfkkebajnpiicnpfamebilmhamkeme) on the Chrome Web Store.
+
+# Github Enterprise support
+
+* Open GitHub +1 options panel from chrome://extensions
+* Add location to your GitHub Enterprise
+* Accept new permission
+

--- a/background.js
+++ b/background.js
@@ -1,0 +1,13 @@
+chrome.tabs.onUpdated.addListener(function(tabId, changeInfo, tab) {
+  if (changeInfo.status !== 'loading') return
+
+  chrome.tabs.executeScript(tabId, {
+    file  : 'content_script.js',
+    runAt : 'document_end'
+  }, function(res) {
+    if (chrome.runtime.lastError || // don't continue if error (i.e. page isn't in permission list)
+        res[0]) { // value of `injected` above: don't inject twice
+      return;
+    }
+  })
+})

--- a/manifest.json
+++ b/manifest.json
@@ -3,16 +3,22 @@
   "description": "Shows you the counts and avatars of those noisy '+1' comments and hides the original comments.",
   "version": "1.4.0",
   "permissions": [
-    "activeTab"
+    "https://github.com/*",
+    "storage"
+  ],
+  "optional_permissions": [
+    "<all_urls>"
   ],
   "icons": {
     "128": "plusone.png"
   },
   "manifest_version": 2,
-  "content_scripts": [
-    {
-      "matches": ["https://github.com/*"],
-      "js": ["content_script.js"]
-    }
-  ]
+  "options_ui": {
+    "page": "options.html",
+    "chrome_style": true
+  },
+  "background": {
+    "scripts": [ "background.js" ],
+    "persistent": false
+  }
 }

--- a/options.html
+++ b/options.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head><title>GitHub +1s Options</title></head>
+<body>
+<label>
+	GitHub Enterprise Url: <input id='gh_url'>
+</label>
+
+<div id="status"></div>
+<div id="error"></div>
+<button id="save">Save</button>
+<script src="options.js"></script>
+</body>
+</html>

--- a/options.js
+++ b/options.js
@@ -1,0 +1,38 @@
+// Saves options to chrome.storage
+function save_options() {
+  var gh_url = document.getElementById('gh_url').value;
+	chrome.permissions.request({
+			origins: [gh_url]
+		}, function(granted) {
+			if (!granted) {
+				var error = document.getElementById('error');
+    		error.textContent = 'Url format: <protocol>://<domain>.<tld>/';
+			}
+		});
+
+  chrome.storage.sync.set({
+    gh_url: gh_url
+  }, function() {
+    // Update status to let user know options were saved.
+    var status = document.getElementById('status');
+    status.textContent = 'Options saved.';
+    setTimeout(function() {
+      status.textContent = '';
+    }, 750);
+  });
+}
+
+// Restores select box and checkbox state using the preferences
+// stored in chrome.storage.
+function restore_options() {
+  chrome.storage.sync.get({
+    gh_url: ''
+  }, function(items) {
+    document.getElementById('gh_url').value = items.gh_url;
+  });
+}
+
+document.addEventListener('DOMContentLoaded', restore_options);
+document.getElementById('save').addEventListener('click',
+    save_options);
+


### PR DESCRIPTION
Hi,

This branch add Github Enterprise support and fix #8 

It add an option screen for the extension, to add GHE location in order to have permission on it.
It also change the way the extension work. The extension now works on background mode (instead of content_script) on each tab update event (when permission for the domain are granted), because that was the simple way i found to make this extension work with the optional_permission.

If anybody have a better idea to do that, please don't hesitate.

I don't know if you're agree with these modification, but if not, please tell me what kind of modification i can made for this great extension to be compatible with Github Enterprise. I'll be happy to improve this PR :)

Thanks again for your work Ryan.

Hope it will help to move forward on this.
