### PR TITLE
Update target element for mutation observer

### DIFF
--- a/content_script.js
+++ b/content_script.js
@@ -72,7 +72,7 @@ var observer = new MutationObserver(function(mutations) {
   }
 });
 
-var container = document.getElementById('js-repo-pjax-container');
+var container = document.querySelector('[data-pjax-container]');
 observer.observe(container, {childList: true, subtree: true});
 
 removePlusOnes();


### PR DESCRIPTION
The extension currently throws on non-repository pages (An example being the [user profile page](https://github.com/DrewML)).

```
content_script.js:76 Uncaught NotFoundError: Failed to execute 'observe' on 'MutationObserver': The provided node was null.
```
